### PR TITLE
Remove base64 encoding from Uploader to prevent double base64 encoded secrets

### DIFF
--- a/pkg/upload/upload.go
+++ b/pkg/upload/upload.go
@@ -1,7 +1,6 @@
 package upload
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -430,11 +429,7 @@ func (u *secretUploader) iterToSecretData(iter FileIter) (map[string][]byte, err
 			if err != nil {
 				return err
 			}
-			src := []byte(content)
-			buf := make([]byte, base64.StdEncoding.EncodedLen(len(src)))
-			base64.StdEncoding.Encode(buf, src)
-
-			data[strings.Replace(file.Name, "/", ".", -1)] = buf
+			data[strings.Replace(file.Name, "/", ".", -1)] = []byte(content)
 		}
 		return nil
 	})

--- a/pkg/upload/upload_test.go
+++ b/pkg/upload/upload_test.go
@@ -1,7 +1,6 @@
 package upload
 
 import (
-	"encoding/base64"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -249,10 +248,8 @@ func assertData(data map[string]string, t *testing.T, name string, contains []st
 	for _, k := range contains {
 		if v, ok := data[k]; ok {
 			content, _ := ioutil.ReadFile(filepath.Join("testdata", k))
-			base64content := make([]byte, base64.StdEncoding.EncodedLen(len(content)))
-			base64.StdEncoding.Encode(base64content, content)
 			if v != string(content) {
-				t.Errorf("%s case failed: content mismatch expected '%s' but got '%s(%s)' instead", name, content, base64content, v)
+				t.Errorf("%s case failed: content mismatch expected '%s' but got '%s' instead", name, content, v)
 			}
 		} else {
 			t.Errorf("%s case failed: expected data with key '%s' in '%s'", name, k, data)

--- a/pkg/upload/upload_test.go
+++ b/pkg/upload/upload_test.go
@@ -2,18 +2,19 @@ package upload
 
 import (
 	"encoding/base64"
-	"gopkg.in/src-d/go-git.v4/plumbing"
-	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
-	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	testclient "k8s.io/client-go/kubernetes/fake"
-	testing2 "k8s.io/client-go/testing"
 	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
 	"testing"
+
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+	testing2 "k8s.io/client-go/testing"
 )
 
 type mockFileIter struct {
@@ -250,7 +251,7 @@ func assertData(data map[string]string, t *testing.T, name string, contains []st
 			content, _ := ioutil.ReadFile(filepath.Join("testdata", k))
 			base64content := make([]byte, base64.StdEncoding.EncodedLen(len(content)))
 			base64.StdEncoding.Encode(base64content, content)
-			if v != string(content) && v != string(base64content) {
+			if v != string(content) {
 				t.Errorf("%s case failed: content mismatch expected '%s' but got '%s(%s)' instead", name, content, base64content, v)
 			}
 		} else {


### PR DESCRIPTION
Secrets created by git2kube are double base64 encoded. This PR removes base64 encoding for SecretUploader.